### PR TITLE
[fix] ast run: cat | cat | ... *100 | cat をulimit -n 30 に対応

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: tishihar <tishihar@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/01/05 12:15:09 by keishii           #+#    #+#              #
-#    Updated: 2025/04/21 16:04:32 by tishihar         ###   ########.fr        #
+#    Updated: 2025/04/27 19:53:34 by tishihar         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -88,9 +88,10 @@ SRC_UTILS		:= \
 				free_str_array.c \
 
 SRC_AST			:= \
+				exec_ast.c \
 				exec_ast_pipe.c \
 				exec_ast_cmd.c \
-				exec_ast.c \
+				exec_child_component.c \
 
 SRC_ENVP		:= \
 				envl.c \

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: keishii <keishii@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: tishihar <tishihar@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/05 12:09:18 by keishii           #+#    #+#             */
-/*   Updated: 2025/04/23 17:51:56 by keishii          ###   ########.fr       */
+/*   Updated: 2025/04/27 19:52:50 by tishihar         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -161,6 +161,7 @@ int		execute_ast(t_ast *ast_node, int fd_in, t_pids *pids);
 int		exec_ast_pipe(t_ast *ast_node, int fd_in, t_pids *pids);
 void	exec_right_cmd(t_ast *ast_node, int fd_in, t_pids *pids);
 void	exec_left_cmd(t_ast *node, int fd_in, int fd_pipe[], t_pids *pids);
+void	exec_cmd(t_ast *node, int fd_in, int fd_out);
 
 // pids
 void	init_pids(t_pids *pids);

--- a/src/ast/exec_ast_cmd.c
+++ b/src/ast/exec_ast_cmd.c
@@ -6,15 +6,11 @@
 /*   By: tishihar <tishihar@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/24 16:07:58 by tishihar          #+#    #+#             */
-/*   Updated: 2025/04/27 19:10:47 by tishihar         ###   ########.fr       */
+/*   Updated: 2025/04/27 19:52:28 by tishihar         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
-
-static void	setup_child_fd(int fd_in, int fd_out);
-static void	check_fd(int fd_in, int fd_out);
-static int	validate_cmd_path(t_ast *node);
 
 // exec_ast_cmd() is used as follows.
 // step1. if there is a redirect arrays, replace fd_in and fd_out.
@@ -37,14 +33,7 @@ void	exec_right_cmd(t_ast *node, int fd_in, t_pids *pids)
 		exit_f("fork failed.");
 	else if (pid == 0)
 	{
-		set_exec_child_handler();
-		check_fd(fd_in, fd_out);
-		setup_child_fd(fd_in, fd_out);
-		if (validate_cmd_path(node))
-			exit(*node->u_data.cmd.stp);
-		execve(node->u_data.cmd.path, node->u_data.cmd.argv,
-			node->u_data.cmd.envp);
-		exit_f("execve failed");
+		exec_cmd(node, fd_in, fd_out);
 	}
 	else
 	{
@@ -73,15 +62,8 @@ void	exec_left_cmd(t_ast *node, int fd_in, int fd_pipe[], t_pids *pids)
 		exit_f("fork failed.");
 	else if (pid == 0)
 	{
-		set_exec_child_handler();
 		close(fd_pipe[0]);
-		check_fd(fd_in, fd_out);
-		setup_child_fd(fd_in, fd_out);
-		if (validate_cmd_path(node))
-			exit(*node->u_data.cmd.stp);
-		execve(node->u_data.cmd.path, node->u_data.cmd.argv,
-			node->u_data.cmd.envp);
-		exit_f("execve failed");
+		exec_cmd(node, fd_in, fd_out);
 	}
 	else
 	{
@@ -90,60 +72,4 @@ void	exec_left_cmd(t_ast *node, int fd_in, int fd_pipe[], t_pids *pids)
 		close(fd_pipe[1]);
 		pids_push_back(pids, pid);
 	}
-}
-
-// this func() determines if the input is correct.
-static void	check_fd(int fd_in, int fd_out)
-{
-	if (fd_in == -1)
-	{
-		perror("fd_in is not open");
-		exit(EXIT_FAILURE);
-	}
-	if (fd_out == -1)
-	{
-		perror("fd_out is not open");
-		exit(EXIT_FAILURE);
-	}
-}
-
-// this func() is set "fd_in" to STDIN, and "fd_out" to STD_OUT
-// if in or out isn't right shape, this is not the case.
-// The case where fd_in is -1 here is the case where the redirection is -1.
-// THE TRUE CASE: fd_out is appropriate, and, fd_out is not STDOUT
-static void	setup_child_fd(int fd_in, int fd_out)
-{
-	if (fd_in != -1 && fd_in != STDIN_FILENO)
-	{
-		dup2(fd_in, STDIN_FILENO);
-		close(fd_in);
-	}
-	if (fd_out != -1 && fd_out != STDOUT_FILENO)
-	{
-		dup2(fd_out, STDOUT_FILENO);
-		close(fd_out);
-	}
-}
-
-static	int	validate_cmd_path(t_ast *node)
-{
-	struct stat	st;
-	char		*path;
-
-	path = node->u_data.cmd.path;
-	if (!path || access(path, F_OK) != 0)
-	{
-		ft_putstr_fd("Command not found.\n", STDERR_FILENO);
-		return (*(node->u_data.cmd.stp) = 127, 1);
-	}
-	if (access(path, X_OK) != 0)
-		return (perror(path), *(node->u_data.cmd.stp) = 126, 1);
-	if (stat(path, &st) != 0)
-		return (perror(path), *(node->u_data.cmd.stp) = 126, 1);
-	if (!S_ISREG(st.st_mode) && !S_ISLNK(st.st_mode))
-	{
-		ft_putstr_fd("Permission denied.\n", STDERR_FILENO);
-		return (*(node->u_data.cmd.stp) = 126, 1);
-	}
-	return (0);
 }

--- a/src/ast/exec_ast_cmd.c
+++ b/src/ast/exec_ast_cmd.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exec_ast_cmd.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: keishii <keishii@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: tishihar <tishihar@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/24 16:07:58 by tishihar          #+#    #+#             */
-/*   Updated: 2025/04/23 17:04:09 by keishii          ###   ########.fr       */
+/*   Updated: 2025/04/27 19:10:47 by tishihar         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,8 +24,10 @@ void	exec_right_cmd(t_ast *node, int fd_in, t_pids *pids)
 {
 	pid_t	pid;
 	int		fd_out;
+	int		fd_in_tmp;
 
 	fd_out = STDOUT_FILENO;
+	fd_in_tmp = fd_in;
 	if (node->u_data.cmd.redirects)
 		if (handle_redirects(node, &fd_in, &fd_out))
 			return ;
@@ -45,7 +47,11 @@ void	exec_right_cmd(t_ast *node, int fd_in, t_pids *pids)
 		exit_f("execve failed");
 	}
 	else
+	{
+		if (fd_in_tmp != STDIN_FILENO)
+			close(fd_in_tmp);
 		pids_push_back(pids, pid);
+	}
 }
 
 // this func() execute cmd, and update pids.
@@ -54,8 +60,10 @@ void	exec_left_cmd(t_ast *node, int fd_in, int fd_pipe[], t_pids *pids)
 {
 	pid_t	pid;
 	int		fd_out;
+	int		fd_in_tmp;
 
 	fd_out = fd_pipe[1];
+	fd_in_tmp = fd_in;
 	if (node->u_data.cmd.redirects)
 		if (handle_redirects(node, &fd_in, &fd_out))
 			return ;
@@ -76,7 +84,12 @@ void	exec_left_cmd(t_ast *node, int fd_in, int fd_pipe[], t_pids *pids)
 		exit_f("execve failed");
 	}
 	else
+	{
+		if (fd_in_tmp != STDIN_FILENO)
+			close(fd_in_tmp);
+		close(fd_pipe[1]);
 		pids_push_back(pids, pid);
+	}
 }
 
 // this func() determines if the input is correct.

--- a/src/ast/exec_ast_pipe.c
+++ b/src/ast/exec_ast_pipe.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exec_ast_pipe.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: keishii <keishii@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: tishihar <tishihar@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 18:31:27 by tishihar          #+#    #+#             */
-/*   Updated: 2025/04/23 12:51:44 by keishii          ###   ########.fr       */
+/*   Updated: 2025/04/27 18:54:32 by tishihar         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,9 +24,7 @@ int	exec_ast_pipe(t_ast *ast_node, int fd_in, t_pids *pids)
 		return (1);
 	}
 	exec_left_cmd(ast_node->u_data.pipe.left, fd_in, fd_pipe, pids);
-	close(fd_pipe[1]);
 	if (execute_ast(ast_node->u_data.pipe.right, fd_pipe[0], pids))
 		return (1);
-	close(fd_pipe[0]);
 	return (0);
 }

--- a/src/ast/exec_child_component.c
+++ b/src/ast/exec_child_component.c
@@ -1,0 +1,85 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   exec_child_component.c                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tishihar <tishihar@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/27 19:47:50 by tishihar          #+#    #+#             */
+/*   Updated: 2025/04/27 19:50:26 by tishihar         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+static void	setup_child_fd(int fd_in, int fd_out);
+static void	check_fd(int fd_in, int fd_out);
+static int	validate_cmd_path(t_ast *node);
+
+void	exec_cmd(t_ast *node, int fd_in, int fd_out)
+{
+	set_exec_child_handler();
+	check_fd(fd_in, fd_out);
+	setup_child_fd(fd_in, fd_out);
+	if (validate_cmd_path(node))
+		exit(*node->u_data.cmd.stp);
+	execve(node->u_data.cmd.path, node->u_data.cmd.argv,
+		node->u_data.cmd.envp);
+	exit_f("execve failed");
+}
+
+// this func() determines if the input is correct.
+static void	check_fd(int fd_in, int fd_out)
+{
+	if (fd_in == -1)
+	{
+		perror("fd_in is not open");
+		exit(EXIT_FAILURE);
+	}
+	if (fd_out == -1)
+	{
+		perror("fd_out is not open");
+		exit(EXIT_FAILURE);
+	}
+}
+
+// this func() is set "fd_in" to STDIN, and "fd_out" to STD_OUT
+// if in or out isn't right shape, this is not the case.
+// The case where fd_in is -1 here is the case where the redirection is -1.
+// THE TRUE CASE: fd_out is appropriate, and, fd_out is not STDOUT
+static void	setup_child_fd(int fd_in, int fd_out)
+{
+	if (fd_in != -1 && fd_in != STDIN_FILENO)
+	{
+		dup2(fd_in, STDIN_FILENO);
+		close(fd_in);
+	}
+	if (fd_out != -1 && fd_out != STDOUT_FILENO)
+	{
+		dup2(fd_out, STDOUT_FILENO);
+		close(fd_out);
+	}
+}
+
+static	int	validate_cmd_path(t_ast *node)
+{
+	struct stat	st;
+	char		*path;
+
+	path = node->u_data.cmd.path;
+	if (!path || access(path, F_OK) != 0)
+	{
+		ft_putstr_fd("Command not found.\n", STDERR_FILENO);
+		return (*(node->u_data.cmd.stp) = 127, 1);
+	}
+	if (access(path, X_OK) != 0)
+		return (perror(path), *(node->u_data.cmd.stp) = 126, 1);
+	if (stat(path, &st) != 0)
+		return (perror(path), *(node->u_data.cmd.stp) = 126, 1);
+	if (!S_ISREG(st.st_mode) && !S_ISLNK(st.st_mode))
+	{
+		ft_putstr_fd("Permission denied.\n", STDERR_FILENO);
+		return (*(node->u_data.cmd.stp) = 126, 1);
+	}
+	return (0);
+}


### PR DESCRIPTION
cat | cat | ... *100 | cat をulimit -n 30 のようにFDの総数を制限して実行できるようにした。

これによって、
大量コマンドを実行するとき（１０２４こまんどとか）に、FDを開けなくなるとかが原理的には起きない。
（リダイレクトを使って１００このファイルを開いて参照できるようにするとか　echo hello > test1 | echo hello > test2 ...はその限りじゃない）